### PR TITLE
[FEATURE] Added fields for social media sharing 

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1,0 +1,89 @@
+<?php
+namespace RichardHaeser\YoastSeoNews\Domain\Model;
+
+class News extends \GeorgRinger\News\Domain\Model\News
+{
+    /**
+     * @var string
+     */
+    protected $ogTitle;
+
+    /**
+     * @var string
+     */
+    protected $ogDescription;
+
+    /**
+     * @var string
+     */
+    protected $twitterTitle;
+
+    /**
+     * @var string
+     */
+    protected $twitterDescription;
+
+    /**
+     * @return string
+     */
+    public function getOgTitle(): string
+    {
+        return $this->ogTitle;
+    }
+
+    /**
+     * @param string $ogTitle
+     */
+    public function setOgTitle(string $ogTitle)
+    {
+        $this->ogTitle = $ogTitle;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOgDescription(): string
+    {
+        return $this->ogDescription;
+    }
+
+    /**
+     * @param string $ogDescription
+     */
+    public function setOgDescription(string $ogDescription)
+    {
+        $this->ogDescription = $ogDescription;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTwitterTitle(): string
+    {
+        return $this->twitterTitle;
+    }
+
+    /**
+     * @param string $twitterTitle
+     */
+    public function setTwitterTitle(string $twitterTitle)
+    {
+        $this->twitterTitle = $twitterTitle;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTwitterDescription(): string
+    {
+        return $this->twitterDescription;
+    }
+
+    /**
+     * @param string $twitterDescription
+     */
+    public function setTwitterDescription(string $twitterDescription)
+    {
+        $this->twitterDescription = $twitterDescription;
+    }
+}

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -14,6 +14,12 @@ class News extends \GeorgRinger\News\Domain\Model\News
     protected $ogDescription;
 
     /**
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\GeorgRinger\News\Domain\Model\FileReference>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
+     */
+    protected $ogImage;
+
+    /**
      * @var string
      */
     protected $twitterTitle;
@@ -22,6 +28,19 @@ class News extends \GeorgRinger\News\Domain\Model\News
      * @var string
      */
     protected $twitterDescription;
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\GeorgRinger\News\Domain\Model\FileReference>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
+     */
+    protected $twitterImage;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->ogImage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $this->twitterImage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+    }
 
     /**
      * @return string
@@ -56,6 +75,22 @@ class News extends \GeorgRinger\News\Domain\Model\News
     }
 
     /**
+     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+     */
+    public function getOgImage(): \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    {
+        return $this->ogImage;
+    }
+
+    /**
+     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $ogImage
+     */
+    public function setOgImage(\TYPO3\CMS\Extbase\Persistence\ObjectStorage $ogImage)
+    {
+        $this->ogImage = $ogImage;
+    }
+
+    /**
      * @return string
      */
     public function getTwitterTitle(): string
@@ -85,5 +120,21 @@ class News extends \GeorgRinger\News\Domain\Model\News
     public function setTwitterDescription(string $twitterDescription)
     {
         $this->twitterDescription = $twitterDescription;
+    }
+
+    /**
+     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+     */
+    public function getTwitterImage(): \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    {
+        return $this->twitterImage;
+    }
+
+    /**
+     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $twitterImage
+     */
+    public function setTwitterImage(\TYPO3\CMS\Extbase\Persistence\ObjectStorage $twitterImage)
+    {
+        $this->twitterImage = $twitterImage;
     }
 }

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -45,7 +45,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return string
      */
-    public function getOgTitle(): string
+    public function getOgTitle()
     {
         return $this->ogTitle;
     }
@@ -61,7 +61,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return string
      */
-    public function getOgDescription(): string
+    public function getOgDescription()
     {
         return $this->ogDescription;
     }
@@ -77,7 +77,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
      */
-    public function getOgImage(): \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    public function getOgImage()
     {
         return $this->ogImage;
     }
@@ -93,7 +93,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return string
      */
-    public function getTwitterTitle(): string
+    public function getTwitterTitle()
     {
         return $this->twitterTitle;
     }
@@ -109,7 +109,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return string
      */
-    public function getTwitterDescription(): string
+    public function getTwitterDescription()
     {
         return $this->twitterDescription;
     }
@@ -125,7 +125,7 @@ class News extends \GeorgRinger\News\Domain\Model\News
     /**
      * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
      */
-    public function getTwitterImage(): \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    public function getTwitterImage()
     {
         return $this->twitterImage;
     }

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -4,5 +4,5 @@ defined('TYPO3_MODE') || die('Access denied.');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
     'yoast_news',
     'Configuration/TSconfig/Page.tsconfig',
-    'yoast news'
+    'Yoast SEO for TYPO3 - EXT:news'
 );

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -6,3 +6,9 @@ defined('TYPO3_MODE') || die('Access denied.');
     'Configuration/TypoScript',
     'Yoast SEO for TYPO3 - EXT:news'
 );
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'yoast_news',
+    'Configuration/TypoScript/CMS8',
+    'Yoast SEO for TYPO3 - EXT:news (CMS8)'
+);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -4,5 +4,5 @@ defined('TYPO3_MODE') || die('Access denied.');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'yoast_news',
     'Configuration/TypoScript',
-    'yoast news'
+    'Yoast SEO for TYPO3 - EXT:news'
 );

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -1,5 +1,37 @@
 <?php
 $llPrefix = 'LLL:EXT:yoast_news/Resources/Private/Language/TCA.xlf:';
+
+$openGraphCropConfiguration = [
+    'config' => [
+        'cropVariants' => [
+            'default' => [
+                'disabled' => true,
+            ],
+            'social' => [
+                'title' => $llPrefix . 'imwizard.crop_variant.social',
+                'coverAreas' => [],
+                'cropArea' => [
+                    'x' => '0.0',
+                    'y' => '0.0',
+                    'width' => '1.0',
+                    'height' => '1.0'
+                ],
+                'allowedAspectRatios' => [
+                    '1.91:1' => [
+                        'title' => $llPrefix . 'imwizard.ratio.191_1',
+                        'value' => 1.91 / 1
+                    ],
+                    'NaN' => [
+                        'title' => 'LLL:EXT:lang/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                        'value' => 0.0
+                    ],
+                ],
+                'selectedRatio' => '1.91:1',
+            ],
+        ],
+    ],
+];
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'tx_news_domain_model_news',
     [
@@ -44,8 +76,127 @@ $llPrefix = 'LLL:EXT:yoast_news/Resources/Private/Language/TCA.xlf:';
                 ]
             ]
         ],
-
+        'og_title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => $llPrefix . 'og_title',
+            'config' => [
+                'type' => 'input',
+                'size' => 40,
+                'max' => 255,
+                'eval' => 'trim'
+            ]
+        ],
+        'og_description' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => $llPrefix . 'og_description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3
+            ]
+        ],
+        'og_image' => [
+            'exclude' => true,
+            'label' => $llPrefix . 'og_image',
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+                'og_image',
+                [
+                    // Use the imageoverlayPalette instead of the basicoverlayPalette
+                    'overrideChildTca' => [
+                        'types' => [
+                            '0' => [
+                                'showitem' => '
+                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                                'showitem' => '
+                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ]
+                        ],
+                        'columns' => [
+                            'crop' => $openGraphCropConfiguration
+                        ]
+                    ],
+                    'behaviour' => [
+                        'allowLanguageSynchronization' => true
+                    ]
+                ],
+                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
+            )
+        ],
+        'twitter_title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => $llPrefix . 'twitter_title',
+            'config' => [
+                'type' => 'input',
+                'size' => 40,
+                'max' => 255,
+                'eval' => 'trim'
+            ]
+        ],
+        'twitter_description' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => $llPrefix . 'twitter_description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3
+            ]
+        ],
+        'twitter_image' => [
+            'exclude' => true,
+            'label' => $llPrefix . 'twitter_image',
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+                'twitter_image',
+                [
+                    // Use the imageoverlayPalette instead of the basicoverlayPalette
+                    'overrideChildTca' => [
+                        'types' => [
+                            '0' => [
+                                'showitem' => '
+                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                                'showitem' => '
+                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ]
+                        ],
+                        'columns' => [
+                            'crop' => $openGraphCropConfiguration
+                        ]
+                    ],
+                    'behaviour' => [
+                        'allowLanguageSynchronization' => true
+                    ]
+                ],
+                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
+            )
+        ],
     ]
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
+    'tx_news_domain_model_news',
+    'yoast-social-og',
+    '
+            --linebreak--, og_title, --linebreak--, og_description, --linebreak--, og_image,
+        '
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
+    'tx_news_domain_model_news',
+    'yoast-social-twitter',
+    '
+            --linebreak--, twitter_title, --linebreak--, twitter_description, --linebreak--, twitter_image,
+        '
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
@@ -88,6 +239,9 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['alternativeTitles']['s
         --palette--;' . $llPrefix . 'news.palettes.metadata;yoast-metadata,
         --palette--;' . $llPrefix . 'news.palettes.readability;yoast-readability,
         --palette--;' . $llPrefix . 'news.palettes.seo;yoast-focuskeyword,
+    --div--;' . $llPrefix . 'news.tabs.social,
+        --palette--;' . $llPrefix . 'news.palettes.og;yoast-social-og,
+        --palette--;' . $llPrefix . 'news.palettes.twitter;yoast-social-twitter,        
     ',
     '',
     'after:bodytext'

--- a/Configuration/TypoScript/CMS8/setup.typoscript
+++ b/Configuration/TypoScript/CMS8/setup.typoscript
@@ -1,0 +1,23 @@
+[globalVar = GP:tx_news_pi1|news > 0] || [globalVar = GP:tx_news_pi1|news_preview > 0]
+    page.meta {
+        description.cObject =< lib.yoastSEO.description
+        robots.cObject < lib.yoastSEO.robotInstructions
+        og:title.cObject =< lib.yoastSEO.og.title
+        og:title.attribute = property
+        og:description.cObject =< lib.yoastSEO.og.description
+        og:description.attribute = property
+        og:image.cObject =< lib.yoastSEO.og.images
+        og:image.attribute = property
+        twitter:title.cObject =< lib.yoastSEO.twitter.title
+        twitter:description.cObject =< lib.yoastSEO.twitter.description
+        twitter:image.cObject =< lib.yoastSEO.twitter.images
+    }
+
+    lib.yoastSEO {
+        canonicalURL >
+        og >
+        twitter >
+        pageTitle >
+        description >
+    }
+[global]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -9,6 +9,14 @@
     lib.yoastSEO.slug.stdWrap.typolink.forceAbsoluteUrl = 0
 [global]
 
+plugin.tx_news {
+    view {
+        partialRootPaths {
+            0 = EXT:news/Resources/Private/Partials/
+            5 = EXT:yoast_news/Resources/Private/Partials/News/
+        }
+    }
+}
 #
 #[globalVar = GP:tx_news_pi1|news > 0] || [globalVar = GP:tx_news_pi1|news_preview > 0]
 #    lib.yoastSEO {

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -17,35 +17,3 @@ plugin.tx_news {
         }
     }
 }
-#
-#[globalVar = GP:tx_news_pi1|news > 0] || [globalVar = GP:tx_news_pi1|news_preview > 0]
-#    lib.yoastSEO {
-#        canonicalURL >
-#        og >
-#        twitter >
-#
-#        pageTitle >
-#        pageTitle = RECORDS
-#        pageTitle {
-#            tables = tx_news_domain_model_news
-#            dontCheckPid = 1
-#            source = {GP:tx_news_pi1|news},{GP:tx_news_pi1|news_preview}
-#            source.insertData = 1
-#
-#            conf.tx_news_domain_model_news = TEXT
-#            conf.tx_news_domain_model_news.field = alternative_title
-#            conf.tx_news_domain_model_news.ifEmpty.field = title
-#        }
-#
-#        description >
-#        description = RECORDS
-#        description {
-#            tables = tx_news_domain_model_news
-#            source = {GP:tx_news_pi1|news},{GP:tx_news_pi1|news_preview}
-#            source.insertData = 1
-#
-#            conf.tx_news_domain_model_news = TEXT
-#            conf.tx_news_domain_model_news.field = description
-#        }
-#    }
-#[global]

--- a/Resources/Private/Language/TCA.xlf
+++ b/Resources/Private/Language/TCA.xlf
@@ -24,6 +24,33 @@
             <trans-unit id="news.field.seoFocusKeyword">
                 <source>Focus keyword</source>
             </trans-unit>
+            <trans-unit id="news.tabs.social" resname="news.tabs.social">
+                <source>Social Media</source>
+            </trans-unit>
+            <trans-unit id="news.palettes.og" resname="news.palettes.og">
+                <source>Open Graph (Facebook)</source>
+            </trans-unit>
+            <trans-unit id="news.palettes.twitter" resname="news.palettes.twitter">
+                <source>Twitter Cards</source>
+            </trans-unit>
+            <trans-unit id="og_title" resname="og_title">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="og_description" resname="og_description">
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="og_image" resname="og_image">
+                <source>Image</source>
+            </trans-unit>
+            <trans-unit id="twitter_title" resname="twitter_title">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="twitter_description" resname="twitter_description">
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="twitter_image" resname="twitter_image">
+                <source>Image</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/News/Detail/Opengraph.html
+++ b/Resources/Private/Partials/News/Detail/Opengraph.html
@@ -1,0 +1,83 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	  xmlns:n="http://typo3.org/ns/GeorgRinger/News/ViewHelpers"
+	  data-namespace-typo3-fluid="true">
+
+<n:metaTag property="og:type" content="{settings.opengraph.type}" />
+<n:metaTag property="og:url" content="" useCurrentDomain="1" />
+<n:metaTag property="og:site_name" content="{settings.opengraph.site_name}" />
+<f:if condition="{newsItem.firstPreview}">
+	<n:metaTag
+		property="og:image"
+		content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
+		forceAbsoluteUrl="1" />
+	<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
+	<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+</f:if>
+
+<f:if condition="{newsItem.ogTitle}">
+	<f:then><n:metaTag property="og:title" content="{newsItem.ogTitle}" /></f:then>
+	<f:else>
+		<f:if condition="{newsItem.alternativeTitle}">
+			<f:then><n:metaTag property="og:title" content="{newsItem.alternativeTitle}" /></f:then>
+			<f:else><n:metaTag property="og:title" content="{newsItem.title}" /></f:else>
+		</f:if>
+	</f:else>
+</f:if>
+
+<f:if condition="{newsItem.ogDescription}">
+	<f:then><n:metaTag property="og:description" content="{newsItem.ogDescription}" /></f:then>
+	<f:else>
+		<f:if condition="{newsItem.description}">
+			<f:then><n:metaTag property="og:description" content="{newsItem.description}" /></f:then>
+			<f:else><n:metaTag property="og:description" content="{newsItem.teaser -> f:format.stripTags()}" /></f:else>
+		</f:if>
+	</f:else>
+</f:if>
+
+<f:if condition="{newsItem.twitterTitle}">
+	<f:then><n:metaTag name="twitter:title" content="{newsItem.twitterTitle}" /></f:then>
+	<f:else>
+		<f:if condition="{newsItem.alternativeTitle}">
+			<f:then><n:metaTag name="twitter:title" content="{newsItem.alternativeTitle}" /></f:then>
+			<f:else><n:metaTag name="twitter:title" content="{newsItem.title}" /></f:else>
+		</f:if>
+	</f:else>
+</f:if>
+
+<f:if condition="{newsItem.twitterDescription}">
+	<f:then><n:metaTag name="twitter:description" content="{newsItem.twitterDescription}" /></f:then>
+	<f:else>
+		<f:if condition="{newsItem.description}">
+			<f:then><n:metaTag name="twitter:description" content="{newsItem.description}" /></f:then>
+			<f:else><n:metaTag name="twitter:description" content="{newsItem.teaser -> f:format.stripTags()}" /></f:else>
+		</f:if>
+	</f:else>
+</f:if>
+
+<f:if condition="{newsItem.description}">
+	<f:then>
+		<n:metaTag name="description" content="{newsItem.description}" />
+	</f:then>
+	<f:else>
+		<n:metaTag name="description" content="{newsItem.teaser -> f:format.stripTags()}" />
+	</f:else>
+</f:if>
+<n:metaTag name="keywords" content="{newsItem.keywords}" />
+<n:metaTag property="fb:admins" content="{settings.opengraph.admins}" />
+<n:metaTag property="og:email" content="{settings.opengraph.email}" />
+<n:metaTag property="og:phone_number" content="{settings.opengraph.phone_number}" />
+<n:metaTag property="og:fax_number" content="{settings.opengraph.fax_number}" />
+<n:metaTag property="og:latitude" content="{settings.opengraph.latitude}" />
+<n:metaTag property="og:longitude" content="{settings.opengraph.longitude}" />
+<n:metaTag property="og:street-address" content="{settings.opengraph.street-address}" />
+<n:metaTag property="og:locality" content="{settings.opengraph.locality}" />
+<n:metaTag property="og:locale" content="{settings.opengraph.locale}" />
+<n:metaTag property="og:region" content="{settings.opengraph.region}" />
+<n:metaTag property="og:postal-code" content="{settings.opengraph.postal-code}" />
+<n:metaTag property="og:country-name" content="{settings.opengraph.country-name}" />
+<f:if condition="{settings.opengraph.twitter.site}">
+	<n:metaTag name="twitter:card" content="{settings.opengraph.twitter.card}" />
+	<n:metaTag name="twitter:site" content="{settings.opengraph.twitter.site}" />
+	<n:metaTag name="twitter:creator" content="{settings.opengraph.twitter.creator}" />
+</f:if>
+</html>

--- a/Resources/Private/Partials/News/Detail/Opengraph.html
+++ b/Resources/Private/Partials/News/Detail/Opengraph.html
@@ -5,14 +5,6 @@
 <n:metaTag property="og:type" content="{settings.opengraph.type}" />
 <n:metaTag property="og:url" content="" useCurrentDomain="1" />
 <n:metaTag property="og:site_name" content="{settings.opengraph.site_name}" />
-<f:if condition="{newsItem.firstPreview}">
-	<n:metaTag
-		property="og:image"
-		content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
-		forceAbsoluteUrl="1" />
-	<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
-	<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
-</f:if>
 
 <f:if condition="{newsItem.ogTitle}">
 	<f:then><n:metaTag property="og:title" content="{newsItem.ogTitle}" /></f:then>
@@ -34,6 +26,27 @@
 	</f:else>
 </f:if>
 
+<f:if condition="{newsItem.ogImage.0}">
+	<f:then>
+		<n:metaTag
+				property="og:image"
+				content="{f:uri.image(src:'{newsItem.ogImage.0.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}"
+				forceAbsoluteUrl="1" />
+		<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
+		<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+	</f:then>
+	<f:else>
+		<f:if condition="{newsItem.firstPreview}">
+			<n:metaTag
+					property="og:image"
+					content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
+					forceAbsoluteUrl="1" />
+			<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
+			<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+		</f:if>
+	</f:else>
+</f:if>
+
 <f:if condition="{newsItem.twitterTitle}">
 	<f:then><n:metaTag name="twitter:title" content="{newsItem.twitterTitle}" /></f:then>
 	<f:else>
@@ -50,6 +63,25 @@
 		<f:if condition="{newsItem.description}">
 			<f:then><n:metaTag name="twitter:description" content="{newsItem.description}" /></f:then>
 			<f:else><n:metaTag name="twitter:description" content="{newsItem.teaser -> f:format.stripTags()}" /></f:else>
+		</f:if>
+	</f:else>
+</f:if>
+
+<f:if condition="{newsItem.twitterImage.0}">
+	<f:then>
+		<n:metaTag
+				name="twitter:image"
+				content="{f:uri.image(src:'{newsItem.twitterImage.0.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}"
+				forceAbsoluteUrl="1" />
+	</f:then>
+	<f:else>
+		<f:if condition="{newsItem.firstPreview}">
+			<n:metaTag
+					property="og:image"
+					content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
+					forceAbsoluteUrl="1" />
+			<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
+			<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
 		</f:if>
 	</f:else>
 </f:if>

--- a/Resources/Private/Partials/News/Detail/Opengraph.html
+++ b/Resources/Private/Partials/News/Detail/Opengraph.html
@@ -73,15 +73,25 @@
 				name="twitter:image"
 				content="{f:uri.image(src:'{newsItem.twitterImage.0.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}"
 				forceAbsoluteUrl="1" />
+
+		<f:if condition="{newsItem.twitterImage.0.alternative}">
+			<n:metaTag
+					name="twitter:image:alt"
+					content="{newsItem.twitterImage.0.alternative}" />
+		</f:if>
 	</f:then>
 	<f:else>
 		<f:if condition="{newsItem.firstPreview}">
 			<n:metaTag
-					property="og:image"
-					content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
+					name="twitter:image"
+					content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}"
 					forceAbsoluteUrl="1" />
-			<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
-			<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+
+			<f:if condition="{newsItem.firstPreview.alternative}">
+				<n:metaTag
+						name="twitter:image:alt"
+						content="{newsItem.firstPreview.alternative}" />
+			</f:if>
 		</f:if>
 	</f:else>
 </f:if>

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "yoast-seo-for-typo3/yoast_seo": "^5.0 || ^6 || ^7",
         "georgringer/news": "^7.0 || ^8",
         "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
+        "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4",
         "php": "^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
         "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
         "php": "^7.0"
     },
+    "autoload": {
+        "psr-4": {
+            "RichardHaeser\\YoastSeoNews\\": "Classes/"
+        }
+    },
     "authors": [
         {
             "name": "Richard Haeser",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes']['Domain/Model/News'][] = 'yoast_news';

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,4 +3,10 @@
 #
 CREATE TABLE tx_news_domain_model_news (
   tx_yoastseo_focuskeyword varchar(100) DEFAULT '' NOT NULL,
+  og_title varchar(255) DEFAULT '' NOT NULL,
+  og_description text,
+  og_image int(11) unsigned DEFAULT '0' NOT NULL,
+  twitter_title varchar(255) DEFAULT '' NOT NULL,
+  twitter_description text,
+  twitter_image int(11) unsigned DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
This feature will add the title, description and image field to News items. When the fields are not filled, there will be a fallback to the original fields in EXT:news.

This feature is sponsored by the great people of [ICTI](https://www.icti.es), Spain

Resolves: #3 