### PR TITLE
[BUGFIX] add missing definitions in SQL for fields that are in TCA

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -9,4 +9,7 @@ CREATE TABLE tx_news_domain_model_news (
   twitter_title varchar(255) DEFAULT '' NOT NULL,
   twitter_description text,
   twitter_image int(11) unsigned DEFAULT '0' NOT NULL,
+  tx_yoastseo_snippetpreview tinyint(3) DEFAULT '0' NOT NULL,
+  tx_yoastseo_readability_analysis tinyint(3) DEFAULT '0' NOT NULL,
+  tx_yoastseo_focuskeyword_analysis tinyint(3) DEFAULT '0' NOT NULL
 );


### PR DESCRIPTION
Had some issues with the upgrade wizard because these fields were missing in the SQL definition.

This fix was also done in the Yoast SEO extension itself. Copied from there.