### PR TITLE
Avoid parent::construct error on News cached class

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -37,7 +37,6 @@ class News extends \GeorgRinger\News\Domain\Model\News
 
     public function __construct()
     {
-        parent::__construct();
         $this->ogImage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
         $this->twitterImage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
     }


### PR DESCRIPTION
When instantiating a News object from a third party extensions (such `EXT:news_importicsxml`) an error is thrown

The error:

    Fatal error: Cannot call constructor

from the cached class News: `/var/cache/code/news/tx_news_domain_model_news.php`. It seems that the problem is that there is no _construct method for the parent class \TYPO3\CMS\Extbase\DomainObject\AbstractEntity. Removing the `parent::_construct()` solves it.