### PR TITLE
Added extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
       "role": "Developer"
     }
   ],
+  "extra": {
+		"typo3/cms": {
+			"extension-key": "yoast_news"
+		}
+	},
   "funding": [
     {
       "type": "buymeacoffee",


### PR DESCRIPTION
```
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
```