### PR TITLE
TYPO3 v11 and v12 compatibility

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,9 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  RichardHaeser\YoastSeoNews\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
     'yoast_news',

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'yoast_news',

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -22,7 +22,7 @@ $openGraphCropConfiguration = [
                         'value' => 1.91 / 1
                     ],
                     'NaN' => [
-                        'title' => 'LLL:EXT:lang/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                        'title' => $llPrefix . 'imwizard.ratio.free',
                         'value' => 0.0
                     ],
                 ],
@@ -100,33 +100,31 @@ $openGraphCropConfiguration = [
         'og_image' => [
             'exclude' => true,
             'label' => $llPrefix . 'og_image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
-                'og_image',
-                [
-                    // Use the imageoverlayPalette instead of the basicoverlayPalette
-                    'overrideChildTca' => [
-                        'types' => [
-                            '0' => [
-                                'showitem' => '
-                                    --palette--;;imageoverlayPalette,
-                                    --palette--;;filePalette'
-                            ],
-                            \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                                'showitem' => '
-                                    --palette--;;imageoverlayPalette,
-                                    --palette--;;filePalette'
-                            ]
+            'config' => [
+                'type' => 'file',
+                'allowed' => 'common-image-types',
+                // Use the imageoverlayPalette instead of the basicoverlayPalette
+                'overrideChildTca' => [
+                    'types' => [
+                        '0' => [
+                            'showitem' => '
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
                         ],
-                        'columns' => [
-                            'crop' => $openGraphCropConfiguration
+                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                            'showitem' => '
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
                         ]
                     ],
-                    'behaviour' => [
-                        'allowLanguageSynchronization' => true
+                    'columns' => [
+                        'crop' => $openGraphCropConfiguration
                     ]
                 ],
-                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
-            )
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true
+                ]
+            ],
         ],
         'twitter_title' => [
             'exclude' => true,
@@ -152,33 +150,31 @@ $openGraphCropConfiguration = [
         'twitter_image' => [
             'exclude' => true,
             'label' => $llPrefix . 'twitter_image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
-                'twitter_image',
-                [
-                    // Use the imageoverlayPalette instead of the basicoverlayPalette
-                    'overrideChildTca' => [
-                        'types' => [
-                            '0' => [
-                                'showitem' => '
-                                    --palette--;;imageoverlayPalette,
-                                    --palette--;;filePalette'
-                            ],
-                            \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                                'showitem' => '
-                                    --palette--;;imageoverlayPalette,
-                                    --palette--;;filePalette'
-                            ]
+            'config' => [
+                'type' => 'file',
+                'allowed' => 'common-image-types',
+                // Use the imageoverlayPalette instead of the basicoverlayPalette
+                'overrideChildTca' => [
+                    'types' => [
+                        '0' => [
+                            'showitem' => '
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
                         ],
-                        'columns' => [
-                            'crop' => $openGraphCropConfiguration
+                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                            'showitem' => '
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
                         ]
                     ],
-                    'behaviour' => [
-                        'allowLanguageSynchronization' => true
+                    'columns' => [
+                        'crop' => $openGraphCropConfiguration
                     ]
                 ],
-                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
-            )
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true
+                ],
+            ],
         ],
     ]
 );

--- a/Configuration/TypoScript/CMS8/setup.typoscript
+++ b/Configuration/TypoScript/CMS8/setup.typoscript
@@ -1,4 +1,4 @@
-[globalVar = GP:tx_news_pi1|news > 0] || [globalVar = GP:tx_news_pi1|news_preview > 0]
+[traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0 || traverse(request.getQueryParams(), 'tx_news_pi1/news_preview') > 0]
     page.meta {
         description.cObject =< lib.yoastSEO.description
         robots.cObject < lib.yoastSEO.robotInstructions

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,4 +1,4 @@
-[globalVar = GP:tx_news_pi1|news_preview > 0]
+[traverse(request.getQueryParams(), 'tx_news_pi1/news_preview') > 0]
     lib.yoastSEO.currentURL.stdWrap.typolink {
         addQueryString.exclude = type,tx_news_pi1[news_preview]
         additionalParams = &tx_news_pi1[news]={GP:tx_news_pi1|news_preview}

--- a/Resources/Private/Language/TCA.xlf
+++ b/Resources/Private/Language/TCA.xlf
@@ -60,6 +60,15 @@
             <trans-unit id="twitter_image" resname="twitter_image">
                 <source>Image</source>
             </trans-unit>
+            <trans-unit id="imwizard.crop_variant.social" resname="imwizard.crop_variant.social">
+                <source>Crop variant social</source>
+            </trans-unit>
+            <trans-unit id="imwizard.ratio.191_1" resname="imwizard.ratio.191_1">
+                <source>1.91 / 1</source>
+            </trans-unit>
+            <trans-unit id="imwizard.ratio.free" resname="imwizard.ratio.free">
+                <source>Free</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/News/Detail/Opengraph.html
+++ b/Resources/Private/Partials/News/Detail/Opengraph.html
@@ -28,21 +28,23 @@
 
 <f:if condition="{newsItem.ogImage.0}">
 	<f:then>
+		<f:variable name="ogImagePath" value="{f:uri.image(src:'{newsItem.ogImage.0.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}" />
 		<n:metaTag
 				property="og:image"
-				content="{f:uri.image(src:'{newsItem.ogImage.0.uid}', treatIdAsReference:1, maxWidth:'1200', cropVariant: 'social')}"
+				content="{ogImagePath}"
 				forceAbsoluteUrl="1" />
-		<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
-		<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+		<n:metaTag property="og:image:width" content="{n:imageSize(property:'width', image:'{ogImagePath}')}" />
+		<n:metaTag property="og:image:height" content="{n:imageSize(property:'height', image:'{ogImagePath}')}" />
 	</f:then>
 	<f:else>
 		<f:if condition="{newsItem.firstPreview}">
+			<f:variable name="ogImagePath" value="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}" />
 			<n:metaTag
 					property="og:image"
-					content="{f:uri.image(src:'{newsItem.firstPreview.uid}', treatIdAsReference:1, maxWidth:'1200')}"
+					content="{ogImagePath}"
 					forceAbsoluteUrl="1" />
-			<n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />
-			<n:metaTag property="og:image:height" content="{n:imageSize(property:'height')}" />
+			<n:metaTag property="og:image:width" content="{n:imageSize(property:'width', image:'{ogImagePath}')}" />
+			<n:metaTag property="og:image:height" content="{n:imageSize(property:'height', image:'{ogImagePath}')}" />
 		</f:if>
 	</f:else>
 </f:if>

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     }
   ],
   "extra": {
-		"typo3/cms": {
-			"extension-key": "yoast_news"
-		}
-	},
+    "typo3/cms": {
+      "extension-key": "yoast_news"
+    }
+  },
   "funding": [
     {
       "type": "buymeacoffee",

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0-or-later",
   "require": {
-    "yoast-seo-for-typo3/yoast_seo": "^5.0 || ^6 || ^7 || ^8",
-    "georgringer/news": "^7.0 || ^8 || ^9",
-    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
-    "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4 || ^11.5",
-    "php": "^7.0"
+    "yoast-seo-for-typo3/yoast_seo": "^6 || ^7 || ^8",
+    "georgringer/news": "^8 || ^9 || ^10",
+    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
+    "typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5",
+    "php": "^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,9 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0-or-later",
   "require": {
-    "yoast-seo-for-typo3/yoast_seo": "^6 || ^7 || ^8",
-    "georgringer/news": "^8 || ^9 || ^10",
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
-    "typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5",
-    "php": "^7.0 || ^8.0"
+    "georgringer/news": "^11",
+    "typo3/cms-core": "^12.4",
+    "yoast-seo-for-typo3/yoast_seo": "^9"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0-or-later",
   "require": {
-    "yoast-seo-for-typo3/yoast_seo": "^5.0 || ^6 || ^7",
-    "georgringer/news": "^7.0 || ^8",
+    "yoast-seo-for-typo3/yoast_seo": "^5.0 || ^6 || ^7 || ^8",
+    "georgringer/news": "^7.0 || ^8 || ^9",
     "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
-    "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4",
+    "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4 || ^11.5",
     "php": "^7.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0-or-later",
   "require": {
-    "georgringer/news": "^11",
-    "typo3/cms-core": "^12.4",
-    "yoast-seo-for-typo3/yoast_seo": "^9"
+    "georgringer/news": "^11.0 || ^12.0",
+    "typo3/cms-core": "^12.4 || ^13.4",
+    "yoast-seo-for-typo3/yoast_seo": "^10.0 || ^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0-or-later",
   "require": {
-    "georgringer/news": "^11.0 || ^12.0",
+    "georgringer/news": "^11.0 || ^12.0 || ^13.0 || ^14.0",
     "typo3/cms-core": "^12.4 || ^13.4",
     "yoast-seo-for-typo3/yoast_seo": "^10.0 || ^11.0"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,9 +9,9 @@ $EM_CONF['yoast_news'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'news' => '8.0.0-10.99.99',
-            'yoast_seo' => '6.0.0-8.99.99',
-            'typo3' => '9.5.0-11.5.99'
+            'news' => '11.0.0-11.99.99',
+            'typo3' => '12.4.0-12.4.99',
+            'yoast_seo' => '9.0.0-9.99.99',
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,9 +9,9 @@ $EM_CONF['yoast_news'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'news' => '7.0.0-9.99.99',
-            'yoast_seo' => '5.0.0-8.99.99',
-            'typo3' => '8.7.0-11.5.99'
+            'news' => '8.0.0-10.99.99',
+            'yoast_seo' => '6.0.0-8.99.99',
+            'typo3' => '9.5.0-11.5.99'
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,9 +9,9 @@ $EM_CONF['yoast_news'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'news' => '7.0.0-8.99.99',
-            'yoast_seo' => '5.0.0-7.99.99',
-            'typo3' => '8.7.0-10.4.99'
+            'news' => '7.0.0-9.99.99',
+            'yoast_seo' => '5.0.0-8.99.99',
+            'typo3' => '8.7.0-11.5.99'
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,7 +9,7 @@ $EM_CONF['yoast_news'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'news' => '11.0.0-12.99.99',
+            'news' => '11.0.0-14.99.99',
             'typo3' => '12.4.0-13.4.99',
             'yoast_seo' => '10.0.0-11.99.99',
         ],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,9 +9,9 @@ $EM_CONF['yoast_news'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'news' => '11.0.0-11.99.99',
-            'typo3' => '12.4.0-12.4.99',
-            'yoast_seo' => '9.0.0-9.99.99',
+            'news' => '11.0.0-12.99.99',
+            'typo3' => '12.4.0-13.4.99',
+            'yoast_seo' => '10.0.0-11.99.99',
         ],
         'conflicts' => [],
         'suggests' => []


### PR DESCRIPTION
ATTENTION
`GeorgRinger\News\ViewHelpers\ImageSizeViewHelper` has change in `ext:news` v9, so the `Opengraph.html` partial was adapted.

ext:news < v9 NO parameter "image" is used:

    <n:metaTag property="og:image:width" content="{n:imageSize(property:'width')}" />

ext:news >= v9 parameter "image" is required:

    <n:metaTag property="og:image:width" content="{n:imageSize(property:'width', image:'{ogImagePath}')}" />

Note:
Final stable version 9 of `ext:news` is not out yet.